### PR TITLE
add "python-compilers.vim" (07/2016)

### DIFF
--- a/2016/07.md
+++ b/2016/07.md
@@ -1,0 +1,5 @@
+## Diego Garcia
+### python-compilers.vim
+Coleção de `compilers` python para o VIM.
+#### Links
+* [repositório](https://github.com/drgarcia1986/python-compilers.vim)


### PR DESCRIPTION
Esse projeto junta alguns `compilers` do vim para python (atualmente `flake8` e `pylint`).

A ideia é usar esses compilers junto com o [vim-dispatch](https://github.com/tpope/vim-dispatch) para poder fazer o syntax checking de forma assíncrona (principal motivador de usar `compilers` ao invés do do plugin [syntastic](https://github.com/scrooloose/syntastic) ).

Irei escrever um post sobre, mas sabe como é né :stuck_out_tongue_closed_eyes: 
